### PR TITLE
changed blink pin to D2

### DIFF
--- a/eg/blink.js
+++ b/eg/blink.js
@@ -19,10 +19,10 @@ board.on("ready", function() {
 
   var state = 1;
 
-  this.pinMode(13, this.MODES.OUTPUT);
+  this.pinMode(2, this.MODES.OUTPUT);
 
   setInterval(function() {
-    this.digitalWrite(13, (state ^= 1));
+    this.digitalWrite(2, (state ^= 1));
   }.bind(this), 500);
 });
 


### PR DESCRIPTION
Pins 10, 11, 12 and 13 are used by the Ethernet shield when connected to an Arduino Uno so you can't use the pin 13 blink LED. Using pin 2 instead.